### PR TITLE
Distinguish between nil and none

### DIFF
--- a/lib/mulang/ruby/ast_processor.rb
+++ b/lib/mulang/ruby/ast_processor.rb
@@ -3,9 +3,12 @@ module Mulang::Ruby
     include AST::Sexp
     include Mulang::Ruby::Sexp
 
+    def process(node)
+      node.nil? ? none : super
+    end
+
     def on_class(node)
       name, superclass, body = *node
-      body ||= s(:nil)
 
       _, class_name = *name
       _, superclass_name = *superclass
@@ -15,7 +18,6 @@ module Mulang::Ruby
 
     def on_module(node)
       name, body = *node
-      body ||= s(:nil)
 
       _, module_name = *name
 
@@ -113,14 +115,12 @@ module Mulang::Ruby
 
     def on_defs(node)
       _target, id, args, body = *node
-      body ||= s(:nil)
 
       simple_method id, process_all(args), process(body)
     end
 
     def on_def(node)
       id, args, body = *node
-      body ||= s(:nil)
 
       case id
       when :equal?, :eql?, :==
@@ -143,7 +143,7 @@ module Mulang::Ruby
     end
 
     def on_nil(_)
-      ms :MuNil
+      mnil
     end
 
     def on_self(_)
@@ -192,8 +192,6 @@ module Mulang::Ruby
 
     def on_if(node)
       condition, if_true, if_false = *node
-      if_true  ||= s(:nil)
-      if_false ||= s(:nil)
 
       ms :If, process(condition), process(if_true), process(if_false)
     end

--- a/lib/mulang/ruby/sexp.rb
+++ b/lib/mulang/ruby/sexp.rb
@@ -4,8 +4,9 @@ module Mulang::Ruby
   module Sexp
     include Mulang::Sexp
 
-    def none
+    def mnil
       ms(:MuNil)
     end
   end
+
 end

--- a/spec/mulang/ruby_spec.rb
+++ b/spec/mulang/ruby_spec.rb
@@ -159,7 +159,7 @@ describe Mulang::Ruby do
 
      context 'nil' do
       let(:code) { %q{nil} }
-      it { expect(result).to eq ms :MuNil }
+      it { expect(result).to eq mnil }
       it { check_valid result }
     end
 
@@ -732,7 +732,7 @@ describe Mulang::Ruby do
                                 :contents=>
                                 [{:tag=>:Self},
                                   {:tag=>:Reference, :contents=>:foo},
-                                  [{:tag=>:Lambda, :contents=>[[{:tag=>:VariablePattern, :contents=>:x}], {:tag=>:MuNil}]}]] }
+                                  [{:tag=>:Lambda, :contents=>[[{:tag=>:VariablePattern, :contents=>:x}], none]}]] }
     end
   end
 end


### PR DESCRIPTION
# :dart: Goal

To treat `nil` and empty blocks as different things, namely `MuNil` and `None`. This is necessary in order to allow some smells like `HasEmptyIfBranches`, `HasEqualIfBranches` and `ShouldInvertIfBranches` to properly work. 

